### PR TITLE
#5 - allow users to create new groups

### DIFF
--- a/lib/sir_alex/groups/group.ex
+++ b/lib/sir_alex/groups/group.ex
@@ -1,0 +1,30 @@
+defmodule SirAlex.Groups.Group do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias SirAlex.Groups.Group
+
+  @attrs [
+    :description,
+    :is_private,
+    :name
+  ]
+
+  @required_attrs @attrs -- [
+    :is_private
+  ]
+
+  schema "groups" do
+    field :description, :string
+    field :is_private, :boolean, default: false
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Group{} = group, attrs) do
+    group
+    |> cast(attrs, @attrs)
+    |> validate_required(@required_attrs)
+  end
+end

--- a/lib/sir_alex/groups/groups.ex
+++ b/lib/sir_alex/groups/groups.ex
@@ -1,0 +1,104 @@
+defmodule SirAlex.Groups do
+  @moduledoc """
+  The Groups context.
+  """
+
+  import Ecto.Query, warn: false
+  alias SirAlex.Repo
+
+  alias SirAlex.Groups.Group
+
+  @doc """
+  Returns the list of groups.
+
+  ## Examples
+
+      iex> list_groups()
+      [%Group{}, ...]
+
+  """
+  def list_groups do
+    Repo.all(Group)
+  end
+
+  @doc """
+  Gets a single group.
+
+  Raises `Ecto.NoResultsError` if the Group does not exist.
+
+  ## Examples
+
+      iex> get_group!(123)
+      %Group{}
+
+      iex> get_group!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_group!(id), do: Repo.get!(Group, id)
+
+  @doc """
+  Creates a group.
+
+  ## Examples
+
+      iex> create_group(%{field: value})
+      {:ok, %Group{}}
+
+      iex> create_group(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_group(attrs \\ %{}) do
+    %Group{}
+    |> Group.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a group.
+
+  ## Examples
+
+      iex> update_group(group, %{field: new_value})
+      {:ok, %Group{}}
+
+      iex> update_group(group, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_group(%Group{} = group, attrs) do
+    group
+    |> Group.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Group.
+
+  ## Examples
+
+      iex> delete_group(group)
+      {:ok, %Group{}}
+
+      iex> delete_group(group)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_group(%Group{} = group) do
+    Repo.delete(group)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking group changes.
+
+  ## Examples
+
+      iex> change_group(group)
+      %Ecto.Changeset{source: %Group{}}
+
+  """
+  def change_group(%Group{} = group) do
+    Group.changeset(group, %{})
+  end
+end

--- a/lib/sir_alex_web/controllers/auth_controller.ex
+++ b/lib/sir_alex_web/controllers/auth_controller.ex
@@ -21,4 +21,11 @@ defmodule SirAlexWeb.AuthController do
   def login(conn, _params) do
     render(conn, "login.html")
   end
+
+  def logout(conn, _params) do
+    conn
+    |> delete_session(:current_user)
+    |> put_flash(:info, "Successfully logged out.")
+    |> redirect(to: "/")
+  end
 end

--- a/lib/sir_alex_web/controllers/group_controller.ex
+++ b/lib/sir_alex_web/controllers/group_controller.ex
@@ -1,0 +1,60 @@
+defmodule SirAlexWeb.GroupController do
+  use SirAlexWeb, :controller
+
+  alias SirAlex.Groups
+  alias SirAlex.Groups.Group
+
+  def index(conn, _params) do
+    groups = Groups.list_groups()
+    render(conn, "index.html", groups: groups)
+  end
+
+  def new(conn, _params) do
+    changeset = Groups.change_group(%Group{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"group" => group_params}) do
+    case Groups.create_group(group_params) do
+      {:ok, group} ->
+        conn
+        |> put_flash(:info, "Group created successfully.")
+        |> redirect(to: group_path(conn, :show, group))
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    group = Groups.get_group!(id)
+    render(conn, "show.html", group: group)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    group = Groups.get_group!(id)
+    changeset = Groups.change_group(group)
+    render(conn, "edit.html", group: group, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "group" => group_params}) do
+    group = Groups.get_group!(id)
+
+    case Groups.update_group(group, group_params) do
+      {:ok, group} ->
+        conn
+        |> put_flash(:info, "Group updated successfully.")
+        |> redirect(to: group_path(conn, :show, group))
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, "edit.html", group: group, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    group = Groups.get_group!(id)
+    {:ok, _group} = Groups.delete_group(group)
+
+    conn
+    |> put_flash(:info, "Group deleted successfully.")
+    |> redirect(to: group_path(conn, :index))
+  end
+end

--- a/lib/sir_alex_web/plugs/current_user.ex
+++ b/lib/sir_alex_web/plugs/current_user.ex
@@ -1,0 +1,14 @@
+defmodule SirAlexWeb.Plugs.CurrentUser do
+  alias Plug.Conn
+
+  def get_current_user(conn, _opts) do
+    case Conn.get_session(conn, :current_user) do
+      nil ->
+        Conn.assign(conn, :is_logged_in, false)
+      user ->
+        conn
+        |> Conn.assign(:current_user, user)
+        |> Conn.assign(:is_logged_in, true)
+    end
+  end
+end

--- a/lib/sir_alex_web/router.ex
+++ b/lib/sir_alex_web/router.ex
@@ -1,9 +1,11 @@
 defmodule SirAlexWeb.Router do
   use SirAlexWeb, :router
+  import SirAlexWeb.Plugs.CurrentUser
 
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
+    plug :get_current_user
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
@@ -16,6 +18,7 @@ defmodule SirAlexWeb.Router do
   scope "/", SirAlexWeb do
     pipe_through :browser # Use the default browser stack
 
+    resources "/groups", GroupController
     resources "/users", UserController, only: [:new, :show]
     get "/", PageController, :index
   end
@@ -24,6 +27,7 @@ defmodule SirAlexWeb.Router do
     pipe_through :browser
 
     get "/login", AuthController, :login
+    get "/logout", AuthController, :logout
     get "/:provider", AuthController, :request
     get "/:provider/callback", AuthController, :callback
   end

--- a/lib/sir_alex_web/templates/group/edit.html.eex
+++ b/lib/sir_alex_web/templates/group/edit.html.eex
@@ -1,0 +1,5 @@
+<h2>Edit Group</h2>
+
+<%= render "form.html", Map.put(assigns, :action, group_path(@conn, :update, @group)) %>
+
+<span><%= link "Back", to: group_path(@conn, :index) %></span>

--- a/lib/sir_alex_web/templates/group/form.html.eex
+++ b/lib/sir_alex_web/templates/group/form.html.eex
@@ -1,0 +1,29 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :description, class: "control-label" %>
+    <%= text_input f, :description, class: "form-control" %>
+    <%= error_tag f, :description %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :is_private, class: "control-label" %>
+    <%= checkbox f, :is_private, class: "checkbox" %>
+    <%= error_tag f, :is_private %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/lib/sir_alex_web/templates/group/index.html.eex
+++ b/lib/sir_alex_web/templates/group/index.html.eex
@@ -1,0 +1,30 @@
+<h2>Listing Groups</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Description</th>
+      <th>Is private</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for group <- @groups do %>
+    <tr>
+      <td><%= group.name %></td>
+      <td><%= group.description %></td>
+      <td><%= group.is_private %></td>
+
+      <td class="text-right">
+        <span><%= link "Show", to: group_path(@conn, :show, group), class: "btn btn-default btn-xs" %></span>
+        <span><%= link "Edit", to: group_path(@conn, :edit, group), class: "btn btn-default btn-xs" %></span>
+        <span><%= link "Delete", to: group_path(@conn, :delete, group), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %></span>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<span><%= link "New Group", to: group_path(@conn, :new) %></span>

--- a/lib/sir_alex_web/templates/group/new.html.eex
+++ b/lib/sir_alex_web/templates/group/new.html.eex
@@ -1,0 +1,5 @@
+<h2>New Group</h2>
+
+<%= render "form.html", Map.put(assigns, :action, group_path(@conn, :create)) %>
+
+<span><%= link "Back", to: group_path(@conn, :index) %></span>

--- a/lib/sir_alex_web/templates/group/show.html.eex
+++ b/lib/sir_alex_web/templates/group/show.html.eex
@@ -1,0 +1,23 @@
+<h2>Show Group</h2>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @group.name %>
+  </li>
+
+  <li>
+    <strong>Description:</strong>
+    <%= @group.description %>
+  </li>
+
+  <li>
+    <strong>Is private:</strong>
+    <%= @group.is_private %>
+  </li>
+
+</ul>
+
+<span><%= link "Edit", to: group_path(@conn, :edit, @group) %></span>
+<span><%= link "Back", to: group_path(@conn, :index) %></span>

--- a/lib/sir_alex_web/templates/layout/app.html.eex
+++ b/lib/sir_alex_web/templates/layout/app.html.eex
@@ -16,8 +16,13 @@
       <header class="header">
         <nav role="navigation">
           <ul class="nav nav-pills pull-right">
+            <%= if @is_logged_in do %>
+            <li><%= link("Create Group", to: "/groups/new")%></li>
+            <li><%= link("Log Out", to: "/auth/logout")%></li>
+            <% else %>
             <li><%= link("Create Account", to: "/users/new")%></li>
             <li><%= link("Log In", to: "/auth/login")%></li>
+            <% end %>
           </ul>
         </nav>
         <h1>Sir Alex</h1>

--- a/lib/sir_alex_web/views/group_view.ex
+++ b/lib/sir_alex_web/views/group_view.ex
@@ -1,0 +1,3 @@
+defmodule SirAlexWeb.GroupView do
+  use SirAlexWeb, :view
+end

--- a/priv/repo/migrations/20171030052337_create_groups.exs
+++ b/priv/repo/migrations/20171030052337_create_groups.exs
@@ -1,0 +1,14 @@
+defmodule SirAlex.Repo.Migrations.CreateGroups do
+  use Ecto.Migration
+
+  def change do
+    create table(:groups) do
+      add :name, :string, default: "", null: false
+      add :description, :string, default: "", null: false
+      add :is_private, :boolean, default: false, null: false
+
+      timestamps()
+    end
+
+  end
+end

--- a/test/sir_alex/groups/groups_test.exs
+++ b/test/sir_alex/groups/groups_test.exs
@@ -1,0 +1,69 @@
+defmodule SirAlex.GroupsTest do
+  use SirAlex.DataCase
+
+  alias SirAlex.Groups
+
+  describe "groups" do
+    alias SirAlex.Groups.Group
+
+    @valid_attrs %{description: "some description", is_private: true, name: "some name"}
+    @update_attrs %{description: "some updated description", is_private: false, name: "some updated name"}
+    @invalid_attrs %{description: nil, is_private: nil, name: nil}
+
+    def group_fixture(attrs \\ %{}) do
+      {:ok, group} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Groups.create_group()
+
+      group
+    end
+
+    test "list_groups/0 returns all groups" do
+      group = group_fixture()
+      assert Groups.list_groups() == [group]
+    end
+
+    test "get_group!/1 returns the group with given id" do
+      group = group_fixture()
+      assert Groups.get_group!(group.id) == group
+    end
+
+    test "create_group/1 with valid data creates a group" do
+      assert {:ok, %Group{} = group} = Groups.create_group(@valid_attrs)
+      assert group.description == "some description"
+      assert group.is_private == true
+      assert group.name == "some name"
+    end
+
+    test "create_group/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Groups.create_group(@invalid_attrs)
+    end
+
+    test "update_group/2 with valid data updates the group" do
+      group = group_fixture()
+      assert {:ok, group} = Groups.update_group(group, @update_attrs)
+      assert %Group{} = group
+      assert group.description == "some updated description"
+      assert group.is_private == false
+      assert group.name == "some updated name"
+    end
+
+    test "update_group/2 with invalid data returns error changeset" do
+      group = group_fixture()
+      assert {:error, %Ecto.Changeset{}} = Groups.update_group(group, @invalid_attrs)
+      assert group == Groups.get_group!(group.id)
+    end
+
+    test "delete_group/1 deletes the group" do
+      group = group_fixture()
+      assert {:ok, %Group{}} = Groups.delete_group(group)
+      assert_raise Ecto.NoResultsError, fn -> Groups.get_group!(group.id) end
+    end
+
+    test "change_group/1 returns a group changeset" do
+      group = group_fixture()
+      assert %Ecto.Changeset{} = Groups.change_group(group)
+    end
+  end
+end

--- a/test/sir_alex_web/controllers/group_controller_test.exs
+++ b/test/sir_alex_web/controllers/group_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule SirAlexWeb.GroupControllerTest do
+  use SirAlexWeb.ConnCase
+
+  alias SirAlex.Groups
+
+  @create_attrs %{description: "some description", is_private: true, name: "some name"}
+  @update_attrs %{description: "some updated description", is_private: false, name: "some updated name"}
+  @invalid_attrs %{description: nil, is_private: nil, name: nil}
+
+  def fixture(:group) do
+    {:ok, group} = Groups.create_group(@create_attrs)
+    group
+  end
+
+  describe "index" do
+    test "lists all groups", %{conn: conn} do
+      conn = get conn, group_path(conn, :index)
+      assert html_response(conn, 200) =~ "Listing Groups"
+    end
+  end
+
+  describe "new group" do
+    test "renders form", %{conn: conn} do
+      conn = get conn, group_path(conn, :new)
+      assert html_response(conn, 200) =~ "New Group"
+    end
+  end
+
+  describe "create group" do
+    test "redirects to show when data is valid", %{conn: conn} do
+      conn = post conn, group_path(conn, :create), group: @create_attrs
+
+      assert %{id: id} = redirected_params(conn)
+      assert redirected_to(conn) == group_path(conn, :show, id)
+
+      conn = get conn, group_path(conn, :show, id)
+      assert html_response(conn, 200) =~ "Show Group"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, group_path(conn, :create), group: @invalid_attrs
+      assert html_response(conn, 200) =~ "New Group"
+    end
+  end
+
+  describe "edit group" do
+    setup [:create_group]
+
+    test "renders form for editing chosen group", %{conn: conn, group: group} do
+      conn = get conn, group_path(conn, :edit, group)
+      assert html_response(conn, 200) =~ "Edit Group"
+    end
+  end
+
+  describe "update group" do
+    setup [:create_group]
+
+    test "redirects when data is valid", %{conn: conn, group: group} do
+      conn = put conn, group_path(conn, :update, group), group: @update_attrs
+      assert redirected_to(conn) == group_path(conn, :show, group)
+
+      conn = get conn, group_path(conn, :show, group)
+      assert html_response(conn, 200) =~ "some updated description"
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, group: group} do
+      conn = put conn, group_path(conn, :update, group), group: @invalid_attrs
+      assert html_response(conn, 200) =~ "Edit Group"
+    end
+  end
+
+  describe "delete group" do
+    setup [:create_group]
+
+    test "deletes chosen group", %{conn: conn, group: group} do
+      conn = delete conn, group_path(conn, :delete, group)
+      assert redirected_to(conn) == group_path(conn, :index)
+      assert_error_sent 404, fn ->
+        get conn, group_path(conn, :show, group)
+      end
+    end
+  end
+
+  defp create_group(_) do
+    group = fixture(:group)
+    {:ok, group: group}
+  end
+end


### PR DESCRIPTION
Closes #5 

Allows users to create new groups, as well as view, edit, and delete existing groups.